### PR TITLE
fix z-index for web3connect

### DIFF
--- a/packages/react-app/src/components/Web3SignIn.js
+++ b/packages/react-app/src/components/Web3SignIn.js
@@ -36,7 +36,10 @@ const Web3SignIn = (props) => {
             w3c: new Web3Modal({
               network: getChainData(+process.env.REACT_APP_NETWORK_ID).network,
               providerOptions,
-              cacheProvider: true
+              cacheProvider: true,
+              theme: {
+                zIndex: 1450
+              }
             })
           };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,11 +5055,6 @@ body-parser@1.19.0, body-parser@^1.16.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-body-scroll-lock@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz#221d87435bcfb50e27ab5d4508735f622aed11a2"
-  integrity sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ==
-
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"


### PR DESCRIPTION
This should fix the fact that the web3connect isn't clickable when you click connect on the raffle modal.